### PR TITLE
Fix timer random usage

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -14,6 +14,8 @@ namespace MacroRecorderReplica
         private double size = 0;
         private bool isRecording = false;
         private bool isPaused = false;
+        private readonly Random random = new();
+        private readonly object randomLock = new();
 
         public MainWindow()
         {
@@ -76,10 +78,13 @@ namespace MacroRecorderReplica
             if (!isPaused)
             {
                 seconds++;
-                if (new Random().NextDouble() > 0.5)
+                lock (randomLock)
                 {
-                    events += new Random().Next(1, 5);
-                    size += new Random().NextDouble() * 0.5;
+                    if (random.NextDouble() > 0.5)
+                    {
+                        events += random.Next(1, 5);
+                        size += random.NextDouble() * 0.5;
+                    }
                 }
 
                 Dispatcher.Invoke(() =>


### PR DESCRIPTION
## Summary
- add a private `Random` field and lock
- use the shared instance in `Timer_Elapsed`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851cba9d33483319291f45ad232caf4