### PR TITLE
Dispose timer when closing window

### DIFF
--- a/MacroRecorderReplica.Tests/GlobalUsings.cs
+++ b/MacroRecorderReplica.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/MacroRecorderReplica.Tests/MacroRecorderReplica.Tests.csproj
+++ b/MacroRecorderReplica.Tests/MacroRecorderReplica.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MacroRecorderReplica.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MacroRecorderReplica.Tests/TimerTests.cs
+++ b/MacroRecorderReplica.Tests/TimerTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Windows;
+using Xunit;
+
+namespace MacroRecorderReplica.Tests;
+
+public class TimerTests
+{
+    [Fact]
+    public void TimerStopsOnWindowClosed()
+    {
+        Exception? captured = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var window = new MacroRecorderReplica.MainWindow();
+                var start = typeof(MacroRecorderReplica.MainWindow).GetMethod("StartRecording_Click", BindingFlags.Instance | BindingFlags.NonPublic);
+                start?.Invoke(window, new object?[] { null, new RoutedEventArgs() });
+                Thread.Sleep(1200);
+                var secondsField = typeof(MacroRecorderReplica.MainWindow).GetField("seconds", BindingFlags.Instance | BindingFlags.NonPublic);
+                int beforeClose = (int)(secondsField?.GetValue(window) ?? 0);
+                window.Close();
+                Thread.Sleep(1500);
+                int afterClose = (int)(secondsField?.GetValue(window) ?? 0);
+                Assert.Equal(beforeClose, afterClose);
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (captured != null)
+        {
+            throw new Xunit.Sdk.XunitException($"Exception in STA thread: {captured}");
+        }
+    }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -105,5 +105,12 @@ namespace MacroRecorderReplica
         {
             Close();
         }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            timer.Stop();
+            timer.Dispose();
+            base.OnClosed(e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- dispose the timer in `MainWindow` by overriding `OnClosed`
- add test project and unit test to ensure timer stops after closing

## Testing
- `dotnet test --no-build` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_6851cbabe7348331a71b35880779a559