### PR TITLE
Remove unused using directive

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Timers;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media;
 
 namespace MacroRecorderReplica


### PR DESCRIPTION
## Summary
- clean up `MainWindow.xaml.cs` by removing `using System.Windows.Controls`

## Testing
- `dotnet build` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_6851cbad56a48331be59da67684674bb