### PR TITLE
Enable nullable reference types

### DIFF
--- a/MacroRecorderReplica.csproj
+++ b/MacroRecorderReplica.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- enable nullable reference types in project settings

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cbb252908331886de62fc87a9449